### PR TITLE
Bump `golangci-lint` and other housekeeping tasks

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Go Environment
         uses: actions/setup-go@v4

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,11 +10,15 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Go Environment
+        uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
-      - uses: actions/checkout@v3
-      - name: golangci-lint
+          go-version-file: 'go.mod'
+
+      - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49.0
+          version: v1.54.2

--- a/.github/workflows/openapi_test.yml
+++ b/.github/workflows/openapi_test.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Go Environment
         uses: actions/setup-go@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,13 @@ jobs:
     name: run
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Go Environment
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-      - run: make test
+
+      - name: Run tests
+        run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Go Environment
         uses: actions/setup-go@v4


### PR DESCRIPTION
# Proposed Changes

- Update the version of golangci-lint to v1.54.2 in the golangci-lint workflow
- Remove the unused go-version parameter in the golangci-lint workflow
- Change the name of the "golangci-lint" step to "Run golangci-lint" in the golangci-lint workflow
- Change the name of the "run" step to "Run tests" in the test workflow
- Remove the unused make test command in the test workflow
- Update the `actions/checkout` version from `v2` to `v3` in the `.github/workflows/openapi_test.yml` file
